### PR TITLE
Hotfix/unexpected shell behaviour

### DIFF
--- a/src/basic_function/concat_char_str.c
+++ b/src/basic_function/concat_char_str.c
@@ -1,19 +1,21 @@
 /**
-* {{ project }}
-* Copyright (C) {{ year }}  {{ organization }}
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-* 
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright (C) 2023 hugo
+ * 
+ * This file is part of TekSH.
+ * 
+ * TekSH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * TekSH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with TekSH.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "shell.h"
 
@@ -21,7 +23,7 @@ char *
 concat_char_str(char concat, char *str, int32_t futur, int32_t a)
 {
     int32_t len_str = _strlen(str);
-    char *dest = (char*)_malloc(sizeof(char) * (len_str + futur + 2));
+    char *dest = (char*)_mallocbucket(sizeof(char) * (len_str + futur + 2));
 
     if (a == 0) {
         dest[0] = concat;

--- a/src/prompt_function/prompt_engine/git_ref.c
+++ b/src/prompt_function/prompt_engine/git_ref.c
@@ -19,29 +19,32 @@
 
 #include "shell.h"
 
-char *
-getgit_branch()
+char *getgit_branch(void)
 {
     char _buf[128] = {0};
-    char *branch = NULL;
-    char *tmp = NULL;
-    size_t len = DEFAULT(len);
-    FILE *fp = fopen(".git/HEAD", "r");
+    char *branch = DEFAULT(branch);
+    size_t len = sizeof(_buf);
+    FILE *fp = popen("git name-rev --name-only HEAD 2>/dev/null", "r");
+
     if (!fp) {
-        return "UNDEFINE";
+        return "UNDEFINED";
     }
 
     if (fgets(_buf, sizeof(_buf), fp) != NULL) {
-        if (strncmp(_buf, "ref: refs/heads/", 16) == 0) {
-            branch = _buf + 16;
-            len = strlen(branch);
-            (len > 0 && branch[len - 1] == '\n') ? branch[len - 1] = '\0' : 0;
-        } else {
-            _print("NONE");
+        len = strlen(_buf);
+        if (len > 0 && _buf[len - 1] == '\n') {
+            _buf[len - 1] = '\0';
         }
+        branch = strdup(_buf);
+    } else {
+        branch = strdup("UNDEFINED");
     }
-    fclose(fp);
-    tmp = strdup(branch);
-    garbage_backup_ptr(tmp);
-    return tmp;
+
+    pclose(fp);
+
+    if (!branch)
+        return "UNDEFINED";
+
+    garbage_backup_ptr(branch);
+    return branch;
 }

--- a/src/prompt_function/prompt_engine/parse_stdin.c
+++ b/src/prompt_function/prompt_engine/parse_stdin.c
@@ -83,7 +83,8 @@ parse_stdin(char *command)
     clean_arg = (char **)_malloc(sizeof(char *) * (a + 1));
     for (int32_t i = 0; arg[i]; i++) {
         if ((_strcmp(arg[i], " ") != 0) || (_strcmp(arg[i], "\t") != 0)) {
-            clean_arg[count] = _strdup(arg[i]);
+            clean_arg[count] = strdup(arg[i]);
+            garbage_backup_bucket_ptr(clean_arg[count]);
             count++;
         }
     }

--- a/src/prompt_function/prompt_engine/prompt_shell.c
+++ b/src/prompt_function/prompt_engine/prompt_shell.c
@@ -79,7 +79,7 @@ char *set_promt(void)
     char start = '[';
     char end = ']';
 
-    if (strcmp("UNDEFINE", getgit_branch()) != 0)
+    if (strcmp("UNDEFINED", getgit_branch()) != 0)
         sprintf(prompt, "\033[0;34m%c\033[1;31m%s\033[0m\033[0;34m%c %s", start, getgit_branch(), end, reset);
     else
         sprintf(prompt, " ");
@@ -114,6 +114,7 @@ void inthand(int32_t signum UNUSED_ARG)
 _wur int32_t
 prompt_shell(shell_t *shell)
 {
+    static char historyFilePath[256] = {0};
     char *line = DEFAULT(line);
     static int32_t first_call = true;
     struct termios old_termios, new_termios;
@@ -144,7 +145,8 @@ prompt_shell(shell_t *shell)
         rl_initialize();
         rl_extend_line_buffer(1024);
         first_call = false;
-        load_history("history.txt");
+        snprintf(historyFilePath, sizeof(historyFilePath), "%s/TekShistory.txt", get_home());
+        load_history(historyFilePath);
         rl_attempted_completion_function = command_completion;
     }
     
@@ -188,7 +190,7 @@ prompt_shell(shell_t *shell)
             add_history(line);
             shell->line = line;
             ENV_PATH = cut_path_env(ENV_SET_ARRAY);
-            save_history("history.txt");
+            save_history(historyFilePath);
         } else if (line) {
             print_str(detail, 0, RD_TTY, 1);
         }


### PR DESCRIPTION
Fix: unexpected shell behaviour when the name of a branch is a commit.
Feat: improved display of branches in the shell.
Fix: the locality of the history.txt file has been set in the home~.
Refactor: history.txt changed to TekShistory.txt to avoid any conflicts.
Fix: Long/Short-term memory correction in relation to garbage collection.
Refactor: delete unnecessary files.